### PR TITLE
feat: Add validation rule - StyleNameImmutableAcrossSeasons

### DIFF
--- a/src/validators/rules/style/__tests__/style-name-immutable-across-seasons.test.ts
+++ b/src/validators/rules/style/__tests__/style-name-immutable-across-seasons.test.ts
@@ -1,0 +1,158 @@
+import { validateStyleNameImmutableAcrossSeasons } from '../style-name-immutable-across-seasons';
+import { ValidationContext, StyleRequest, MasterStyle } from '../../../types';
+
+describe('validateStyleNameImmutableAcrossSeasons', () => {
+  const baseCurrentRecord: StyleRequest = {
+    style_code: 'FW24-TS-001',
+    name: 'Classic Tee FW24',
+    category: 'Apparel',
+    gender: 'Unisex',
+    size_range: 'XS-XL',
+    vertical: 'Sportswear',
+    season_code: 'FW24',
+    origin_country: 'China',
+    product_type: 'T-Shirt',
+  };
+
+  const baseExistingRecord: MasterStyle = {
+    style_code: 'FW24-TS-001',
+    name: 'Classic Tee FW24',
+    category: 'Apparel',
+    gender: 'Unisex',
+    size_range: 'XS-XL',
+    vertical: 'Sportswear',
+    season_code: 'FW24',
+    status: 'Approved',
+    data: {},
+  };
+
+  it('should fail validation when both name and season_code change', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseCurrentRecord,
+        name: 'Updated Classic Tee SS25',
+        season_code: 'SS25',
+      },
+      existingRecord: {
+        ...baseExistingRecord,
+        name: 'Classic Tee FW24',
+        season_code: 'FW24',
+      },
+      severity: 'HARD',
+    };
+
+    const result = validateStyleNameImmutableAcrossSeasons(context);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('Style name cannot change between seasons.');
+    expect(result.message).toContain('Previous name: "Classic Tee FW24" (Season: FW24), Current name: "Updated Classic Tee SS25" (Season: SS25).');
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('name');
+    expect(result.oldValue).toBe('Classic Tee FW24');
+    expect(result.newValue).toBe('Updated Classic Tee SS25');
+    expect(result.context).toEqual(expect.objectContaining({
+      previous_name: 'Classic Tee FW24',
+      current_name: 'Updated Classic Tee SS25',
+      previous_season: 'FW24',
+      current_season: 'SS25',
+      style_code: 'FW24-TS-001',
+    }));
+  });
+
+  it('should pass validation when name changes but season_code remains the same', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseCurrentRecord,
+        name: 'New Padded Jacket FW24',
+        season_code: 'FW24', // Season code is unchanged
+      },
+      existingRecord: {
+        ...baseExistingRecord,
+        name: 'Padded Jacket FW24',
+        season_code: 'FW24',
+      },
+      severity: 'HARD',
+    };
+
+    const result = validateStyleNameImmutableAcrossSeasons(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('name');
+    expect(result.oldValue).toBe('Padded Jacket FW24');
+    expect(result.newValue).toBe('New Padded Jacket FW24');
+    expect(result.context.reason).toBe('Name changed, but season code remained the same (allowed)');
+  });
+
+  it('should pass validation when season_code changes but name remains the same', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseCurrentRecord,
+        name: 'Classic Tee FW24',
+        season_code: 'SS25', // Season code changed
+      },
+      existingRecord: {
+        ...baseExistingRecord,
+        name: 'Classic Tee FW24',
+        season_code: 'FW24',
+      },
+      severity: 'HARD',
+    };
+
+    const result = validateStyleNameImmutableAcrossSeasons(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('name');
+    expect(result.oldValue).toBe('Classic Tee FW24');
+    expect(result.newValue).toBe('Classic Tee FW24');
+    expect(result.context.reason).toBe('Season code changed, but name remained the same (allowed)');
+  });
+
+  it('should pass validation when neither name nor season_code change', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseCurrentRecord,
+        name: 'Classic Tee FW24',
+        season_code: 'FW24',
+      },
+      existingRecord: {
+        ...baseExistingRecord,
+        name: 'Classic Tee FW24',
+        season_code: 'FW24',
+      },
+      severity: 'HARD',
+    };
+
+    const result = validateStyleNameImmutableAcrossSeasons(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('name');
+    expect(result.oldValue).toBe('Classic Tee FW24');
+    expect(result.newValue).toBe('Classic Tee FW24');
+    expect(result.context.reason).toBe('Neither name nor season code changed');
+  });
+
+  it('should pass validation for new entity creation (no existingRecord)', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseCurrentRecord,
+        style_code: 'NEW-TS-001',
+        name: 'Brand New Tee SS25',
+        season_code: 'SS25',
+      },
+      existingRecord: null,
+      severity: 'HARD',
+    };
+
+    const result = validateStyleNameImmutableAcrossSeasons(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('name');
+    expect(result.oldValue).toBeUndefined(); // Or null, depending on how oldValue is set for new records
+    expect(result.newValue).toBe('Brand New Tee SS25');
+    expect(result.context.reason).toBe('New style creation - no historical comparison needed');
+  });
+});

--- a/src/validators/rules/style/index.ts
+++ b/src/validators/rules/style/index.ts
@@ -1,0 +1,1 @@
+export { validateStyleNameImmutableAcrossSeasons } from './style-name-immutable-across-seasons';

--- a/src/validators/rules/style/style-name-immutable-across-seasons.ts
+++ b/src/validators/rules/style/style-name-immutable-across-seasons.ts
@@ -1,0 +1,85 @@
+/**
+ * Rule: The `name` field cannot be changed if the `season_code` field has also changed from its previous historical value.
+ * Entity: Style
+ * Field: name
+ * Severity: HARD
+ * When: Update
+ * 
+ * Description:
+ * Validates that the `name` field of a style cannot be changed if its `season_code` has also been updated.
+ * This rule ensures consistency of style names across different seasons, preventing unintended re-branding
+ * or confusion when a style is carried over or re-introduced under a new season code.
+ */
+export function validateStyleNameImmutableAcrossSeasons(
+  context: ValidationContext
+): ValidationResult {
+  const { currentRecord, existingRecord, severity } = context;
+  
+  // Cast to StyleRequest since this is a style validation
+  const current = currentRecord as StyleRequest;
+  const existing = existingRecord as MasterStyle | null;
+  
+  // If no existing record, this is a new style creation - always valid
+  if (!existing) {
+    return {
+      valid: true,
+      severity,
+      context: {
+        reason: 'New style creation - no historical comparison needed',
+        style_code: current.style_code,
+      },
+      ruleName: 'StyleNameImmutableAcrossSeasons',
+      fieldName: 'name',
+      newValue: current.name,
+    };
+  }
+  
+  // Check if the style name has changed
+  const nameChanged = current.name !== existing.name;
+  // Check if the season code has changed
+  const seasonChanged = current.season_code !== existing.season_code;
+  
+  // Rule violation: name changed while transitioning seasons
+  if (nameChanged && seasonChanged) {
+    return {
+      valid: false,
+      message: `Style name cannot change between seasons. Previous name: "${existing.name}" (Season: ${existing.season_code}), Current name: "${current.name}" (Season: ${current.season_code}).`,
+      severity,
+      context: {
+        previous_name: existing.name,
+        current_name: current.name,
+        previous_season: existing.season_code,
+        current_season: current.season_code,
+        style_code: current.style_code,
+      },
+      ruleName: 'StyleNameImmutableAcrossSeasons',
+      fieldName: 'name',
+      oldValue: existing.name,
+      newValue: current.name,
+    };
+  }
+  
+  // Valid scenarios:
+  // 1. Name unchanged (regardless of season change)
+  // 2. Season unchanged (regardless of name change)
+  return {
+    valid: true,
+    severity,
+    context: {
+      reason: nameChanged 
+        ? 'Name changed, but season code remained the same (allowed)'
+        : seasonChanged
+          ? 'Season code changed, but name remained the same (allowed)'
+          : 'Neither name nor season code changed',
+      style_code: current.style_code,
+      previous_name: existing.name,
+      current_name: current.name,
+      previous_season: existing.season_code,
+      current_season: current.season_code,
+    },
+    ruleName: 'StyleNameImmutableAcrossSeasons',
+    fieldName: 'name',
+    oldValue: existing.name,
+    newValue: current.name,
+  };
+}


### PR DESCRIPTION
The `name` field cannot be changed if the `season_code` field has also changed from its previous historical value.

This PR adds validation for `name` on `Style` entity.

Validation Logic:
- Prevents changes to the style's `name` if its `season_code` is also updated.
- Allows `name` changes if the `season_code` remains the same.
- Allows `season_code` changes if the `name` remains the same.

Severity: HARD