### PR TITLE
feat: Add validation rule - SalesColorCodeAllowedValues

### DIFF
--- a/src/validators/rules/product/__tests__/sales-color-code-allowed-values.test.ts
+++ b/src/validators/rules/product/__tests__/sales-color-code-allowed-values.test.ts
@@ -1,0 +1,148 @@
+import { validateSalesColorCodeAllowedValues } from '../sales-color-code-allowed-values';
+import { ValidationContext, ProductRequest, MasterProduct } from '../../../types';
+
+describe('validateSalesColorCodeAllowedValues', () => {
+  const baseProduct: ProductRequest = {
+    code: 'FW24-TS-001-BLU',
+    style_code: 'FW24-TS-001',
+    sales_color_code: 'blue',
+    sales_color_name: 'Sky Blue',
+    sales_availability: 'In Stock',
+    season_code: 'FW24',
+    drop_out_date: null,
+    original_launch_date: '2024-08-15',
+  };
+
+  it('should fail validation - sales_color_code is not black or red (invalid_example)', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseProduct,
+        sales_color_code: 'blue',
+      },
+      existingRecord: null,
+      severity: 'SOFT',
+    };
+
+    const result = validateSalesColorCodeAllowedValues(context);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("Sales color code 'blue' is not allowed. It must be one of: black, red.");
+    expect(result.fieldName).toBe('sales_color_code');
+    expect(result.severity).toBe('SOFT');
+    expect(result.newValue).toBe('blue');
+  });
+
+  it('should pass validation - sales_color_code is red (valid_example)', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseProduct,
+        sales_color_code: 'red',
+      },
+      existingRecord: null,
+      severity: 'SOFT',
+    };
+
+    const result = validateSalesColorCodeAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldName).toBe('sales_color_code');
+    expect(result.severity).toBe('SOFT');
+    expect(result.newValue).toBe('red');
+  });
+
+  it('should pass validation - sales_color_code is black', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseProduct,
+        sales_color_code: 'black',
+      },
+      existingRecord: null,
+      severity: 'SOFT',
+    };
+
+    const result = validateSalesColorCodeAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldName).toBe('sales_color_code');
+    expect(result.severity).toBe('SOFT');
+    expect(result.newValue).toBe('black');
+  });
+
+  it('should pass validation for new entity creation with a valid sales_color_code', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseProduct,
+        sales_color_code: 'red',
+      },
+      existingRecord: null, // No historical data
+      severity: 'SOFT',
+    };
+
+    const result = validateSalesColorCodeAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldName).toBe('sales_color_code');
+    expect(result.newValue).toBe('red');
+  });
+
+  it('should fail validation for update with an invalid sales_color_code', () => {
+    const existingProduct: MasterProduct = {
+      code: 'FW24-TS-001-RED',
+      style_code: 'FW24-TS-001',
+      sales_color_code: 'red',
+      sales_color_name: 'Fiery Red',
+      sales_availability: 'In Stock',
+      season_code: 'FW24',
+      status: 'Active',
+      data: {},
+    };
+
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseProduct,
+        code: 'FW24-TS-001-RED',
+        sales_color_code: 'green', // Invalid update
+      },
+      existingRecord: existingProduct,
+      severity: 'SOFT',
+    };
+
+    const result = validateSalesColorCodeAllowedValues(context);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("Sales color code 'green' is not allowed.");
+    expect(result.fieldName).toBe('sales_color_code');
+    expect(result.oldValue).toBe('red');
+    expect(result.newValue).toBe('green');
+  });
+
+  it('should pass validation for update with a valid sales_color_code', () => {
+    const existingProduct: MasterProduct = {
+      code: 'FW24-TS-001-RED',
+      style_code: 'FW24-TS-001',
+      sales_color_code: 'red',
+      sales_color_name: 'Fiery Red',
+      sales_availability: 'In Stock',
+      season_code: 'FW24',
+      status: 'Active',
+      data: {},
+    };
+
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseProduct,
+        code: 'FW24-TS-001-RED',
+        sales_color_code: 'black', // Valid update
+      },
+      existingRecord: existingProduct,
+      severity: 'SOFT',
+    };
+
+    const result = validateSalesColorCodeAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldName).toBe('sales_color_code');
+    expect(result.oldValue).toBe('red');
+    expect(result.newValue).toBe('black');
+  });
+});

--- a/src/validators/rules/product/index.ts
+++ b/src/validators/rules/product/index.ts
@@ -1,0 +1,1 @@
+export { validateSalesColorCodeAllowedValues } from './sales-color-code-allowed-values';

--- a/src/validators/rules/product/sales-color-code-allowed-values.ts
+++ b/src/validators/rules/product/sales-color-code-allowed-values.ts
@@ -1,0 +1,59 @@
+/**
+ * Rule: Sales color code must be one of 'black' or 'red'
+ * Entity: Product
+ * Field: sales_color_code
+ * Severity: SOFT
+ * When: Both
+ *
+ * Description:
+ * Validates that the `sales_color_code` for a product is restricted to specific, approved values ('black' or 'red').
+ * This ensures consistency and adherence to predefined color options within the product catalog.
+ */
+import { ValidationContext, ValidationResult, ProductRequest, MasterProduct } from '../../../types';
+
+export function validateSalesColorCodeAllowedValues(
+  context: ValidationContext
+): ValidationResult {
+  const { currentRecord, existingRecord, severity } = context;
+
+  // Cast to ProductRequest since this is a product validation
+  const current = currentRecord as ProductRequest;
+  const existing = existingRecord as MasterProduct | null;
+
+  const allowedColorCodes = ['black', 'red'];
+  const currentSalesColorCode = current.sales_color_code?.toLowerCase(); // Normalize for comparison
+
+  // Check if the current sales_color_code is one of the allowed values
+  if (!allowedColorCodes.includes(currentSalesColorCode)) {
+    return {
+      valid: false,
+      message: `Sales color code '${current.sales_color_code}' is not allowed. It must be one of: ${allowedColorCodes.join(', ')}.`, 
+      severity,
+      context: {
+        allowed_values: allowedColorCodes,
+        provided_value: current.sales_color_code,
+        product_code: current.code,
+        style_code: current.style_code,
+      },
+      ruleName: 'SalesColorCodeAllowedValues',
+      fieldName: 'sales_color_code',
+      oldValue: existing?.sales_color_code ?? null,
+      newValue: current.sales_color_code,
+    };
+  }
+
+  // If the sales_color_code is one of the allowed values, the validation passes
+  return {
+    valid: true,
+    severity,
+    context: {
+      allowed_values: allowedColorCodes,
+      provided_value: current.sales_color_code,
+      product_code: current.code,
+    },
+    ruleName: 'SalesColorCodeAllowedValues',
+    fieldName: 'sales_color_code',
+    oldValue: existing?.sales_color_code ?? null,
+    newValue: current.sales_color_code,
+  };
+}


### PR DESCRIPTION
The 'sales_color_code' for a product must be one of 'black' or 'red'.

This PR adds validation for `sales_color_code` on Product entity.

Validation Logic:
- Checks if the `sales_color_code` is either 'black' or 'red'.

Severity: SOFT