### PR TITLE
feat: Add validation rule - ProductTypeMustBeTestOrDumb

### DIFF
--- a/src/validators/rules/style/__tests__/product-type-must-be-test-or-dumb.test.ts
+++ b/src/validators/rules/style/__tests__/product-type-must-be-test-or-dumb.test.ts
@@ -1,0 +1,155 @@
+import { validateProductTypeMustBeTestOrDumb } from '../product-type-must-be-test-or-dumb';
+import { ValidationContext, StyleRequest } from '../../../types';
+
+describe('validateProductTypeMustBeTestOrDumb', () => {
+  const baseStyleRequest: StyleRequest = {
+    style_code: 'SS25-SHOE-001',
+    name: 'Spring Sneaker',
+    category: 'Footwear',
+    gender: 'Unisex',
+    size_range: 'EU 36-47',
+    vertical: 'Lifestyle',
+    season_code: 'SS25'
+  };
+
+  it('should fail validation when product_type is an invalid value (e.g., "footwear") - HARD severity', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseStyleRequest,
+        product_type: 'footwear'
+      },
+      existingRecord: null,
+      severity: 'HARD'
+    };
+
+    const result = validateProductTypeMustBeTestOrDumb(context);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("Product type must be one of 'test', 'dumb'. Current value: 'footwear'.");
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('product_type');
+    expect(result.newValue).toBe('footwear');
+  });
+
+  it('should pass validation when product_type is "test"', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseStyleRequest,
+        product_type: 'test'
+      },
+      existingRecord: null,
+      severity: 'HARD'
+    };
+
+    const result = validateProductTypeMustBeTestOrDumb(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldName).toBe('product_type');
+    expect(result.newValue).toBe('test');
+  });
+
+  it('should pass validation when product_type is "dumb"', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseStyleRequest,
+        product_type: 'dumb'
+      },
+      existingRecord: null,
+      severity: 'HARD'
+    };
+
+    const result = validateProductTypeMustBeTestOrDumb(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldName).toBe('product_type');
+    expect(result.newValue).toBe('dumb');
+  });
+
+  it('should pass validation when product_type is null (optional field)', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseStyleRequest,
+        product_type: null
+      },
+      existingRecord: null,
+      severity: 'HARD'
+    };
+
+    const result = validateProductTypeMustBeTestOrDumb(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldName).toBe('product_type');
+    expect(result.newValue).toBeNull();
+  });
+
+  it('should pass validation when product_type is undefined (optional field)', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseStyleRequest,
+        product_type: undefined
+      },
+      existingRecord: null,
+      severity: 'HARD'
+    };
+
+    const result = validateProductTypeMustBeTestOrDumb(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldName).toBe('product_type');
+    expect(result.newValue).toBeUndefined();
+  });
+
+  it('should pass validation for an update where product_type remains valid', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseStyleRequest,
+        product_type: 'test'
+      },
+      existingRecord: {
+        style_code: 'SS25-SHOE-001',
+        name: 'Spring Sneaker',
+        category: 'Footwear',
+        gender: 'Unisex',
+        size_range: 'EU 36-47',
+        vertical: 'Lifestyle',
+        season_code: 'SS25',
+        status: 'Approved',
+        data: { product_type: 'test' }
+      },
+      severity: 'HARD'
+    };
+
+    const result = validateProductTypeMustBeTestOrDumb(context);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should fail validation for an update where product_type changes to an invalid value', () => {
+    const context: ValidationContext = {
+      currentRecord: {
+        ...baseStyleRequest,
+        product_type: 'invalid_type'
+      },
+      existingRecord: {
+        style_code: 'SS25-SHOE-001',
+        name: 'Spring Sneaker',
+        category: 'Footwear',
+        gender: 'Unisex',
+        size_range: 'EU 36-47',
+        vertical: 'Lifestyle',
+        season_code: 'SS25',
+        status: 'Approved',
+        data: { product_type: 'test' }
+      },
+      severity: 'HARD'
+    };
+
+    const result = validateProductTypeMustBeTestOrDumb(context);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("Product type must be one of 'test', 'dumb'. Current value: 'invalid_type'.");
+    expect(result.fieldName).toBe('product_type');
+    expect(result.newValue).toBe('invalid_type');
+    expect(result.oldValue).toBe('test'); // Assuming existingRecord.data.product_type can be accessed or inferred
+  });
+});

--- a/src/validators/rules/style/index.ts
+++ b/src/validators/rules/style/index.ts
@@ -1,0 +1,1 @@
+export { validateProductTypeMustBeTestOrDumb } from './product-type-must-be-test-or-dumb';

--- a/src/validators/rules/style/product-type-must-be-test-or-dumb.ts
+++ b/src/validators/rules/style/product-type-must-be-test-or-dumb.ts
@@ -1,0 +1,67 @@
+/**
+ * Rule: product_type should be one of test or dumb for styles.
+ * Entity: Style
+ * Field: product_type
+ * Severity: HARD
+ * When: Both
+ *
+ * Description:
+ * This rule ensures that the 'product_type' field for a style, if provided,
+ * must be one of the predefined values: 'test' or 'dumb'. This helps maintain
+ * data integrity and consistency for style categorization within the system.
+ */
+export function validateProductTypeMustBeTestOrDumb(
+  context: ValidationContext
+): ValidationResult {
+  const { currentRecord, severity } = context;
+
+  // Cast to StyleRequest since this is a style validation
+  const current = currentRecord as StyleRequest;
+
+  // Allowed values for product_type
+  const allowedProductTypes = ['test', 'dumb'];
+
+  // If product_type is null or undefined, it's considered valid as the field is optional
+  if (current.product_type === null || current.product_type === undefined) {
+    return {
+      valid: true,
+      severity,
+      context: {
+        reason: 'product_type is optional and not provided.',
+        style_code: current.style_code,
+      },
+      ruleName: 'ProductTypeMustBeTestOrDumb',
+      fieldName: 'product_type',
+      newValue: current.product_type,
+    };
+  }
+
+  // Check if the provided product_type is one of the allowed values
+  if (!allowedProductTypes.includes(current.product_type)) {
+    return {
+      valid: false,
+      message: `Product type must be one of '${allowedProductTypes.join("', '")}'. Current value: '${current.product_type}'.`,
+      severity,
+      context: {
+        style_code: current.style_code,
+        allowed_values: allowedProductTypes,
+      },
+      ruleName: 'ProductTypeMustBeTestOrDumb',
+      fieldName: 'product_type',
+      newValue: current.product_type,
+    };
+  }
+
+  // If the product_type is one of the allowed values, it's valid
+  return {
+    valid: true,
+    severity,
+    context: {
+      reason: 'product_type is valid.',
+      style_code: current.style_code,
+    },
+    ruleName: 'ProductTypeMustBeTestOrD_umb',
+    fieldName: 'product_type',
+    newValue: current.product_type,
+  };
+}


### PR DESCRIPTION
product_type should be one of test or dumb for styles.

This PR adds validation for product_type on Style entity.

Validation Logic:
- Checks if the `product_type` field, if provided, is either 'test' or 'dumb'.
- If `product_type` is null or undefined, it is considered valid as the field is optional.

Severity: HARD