### PR TITLE
feat: Add validation rule - SizeRangeSMorLAllowedValues

### DIFF
--- a/src/validators/rules/style/__tests__/size-range-s-m-or-l-allowed-values.test.ts
+++ b/src/validators/rules/style/__tests__/size-range-s-m-or-l-allowed-values.test.ts
@@ -1,0 +1,165 @@
+import { validateSizeRangeSMorLAllowedValues } from '../size-range-s-m-or-l-allowed-values';
+import { ValidationContext, StyleRequest, MasterStyle } from '../../../types';
+
+describe('validateSizeRangeSMorLAllowedValues', () => {
+  const ruleName = 'SizeRangeSMorLAllowedValues';
+  const fieldName = 'size_range';
+  const severity = 'HARD';
+
+  it('should fail validation - attempting to update a style with an unallowed size_range', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "SS25-TOP-001",
+      name: "Classic T-Shirt",
+      category: "Apparel",
+      gender: "Female",
+      size_range: "XS", // Invalid value
+      vertical: "Lifestyle",
+      season_code: "SS25",
+      origin_country: "BD",
+      product_type: "T-Shirt"
+    };
+
+    const existingRecord: MasterStyle = {
+      style_code: "SS25-TOP-001",
+      name: "Classic T-Shirt",
+      category: "Apparel",
+      gender: "Female",
+      size_range: "S", // Original valid value
+      vertical: "Lifestyle",
+      season_code: "SS25",
+      status: "Approved",
+      data: {}
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord,
+      severity,
+    };
+
+    const result = validateSizeRangeSMorLAllowedValues(context);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("The 'size_range' value 'XS' is not allowed during update. It must be one of: S, M, L.");
+    expect(result.severity).toBe(severity);
+    expect(result.ruleName).toBe(ruleName);
+    expect(result.fieldName).toBe(fieldName);
+    expect(result.newValue).toBe(currentRecord.size_range);
+    expect(result.oldValue).toBe(existingRecord.size_range);
+  });
+
+  it('should pass validation - successfully updating a style with an allowed size_range (M)', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "SS25-DRS-002",
+      name: "Summer Dress",
+      category: "Apparel",
+      gender: "Female",
+      size_range: "M", // Valid value
+      vertical: "Fashion",
+      season_code: "SS25",
+      origin_country: "TR",
+      product_type: "Dress"
+    };
+
+    const existingRecord: MasterStyle = {
+      style_code: "SS25-DRS-002",
+      name: "Summer Dress",
+      category: "Apparel",
+      gender: "Female",
+      size_range: "S", // Original valid value
+      vertical: "Fashion",
+      season_code: "SS25",
+      status: "Approved",
+      data: {}
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord,
+      severity,
+    };
+
+    const result = validateSizeRangeSMorLAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.message).toBeUndefined();
+    expect(result.severity).toBe(severity);
+    expect(result.ruleName).toBe(ruleName);
+    expect(result.fieldName).toBe(fieldName);
+    expect(result.newValue).toBe(currentRecord.size_range);
+    expect(result.oldValue).toBe(existingRecord.size_range);
+  });
+
+  it('should pass validation - successfully updating a style with an allowed size_range (L)', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "SS25-DRS-003",
+      name: "Evening Gown",
+      category: "Apparel",
+      gender: "Female",
+      size_range: "L", // Valid value
+      vertical: "Fashion",
+      season_code: "SS25",
+      origin_country: "IT",
+      product_type: "Dress"
+    };
+
+    const existingRecord: MasterStyle = {
+      style_code: "SS25-DRS-003",
+      name: "Evening Gown",
+      category: "Apparel",
+      gender: "Female",
+      size_range: "M", // Original valid value
+      vertical: "Fashion",
+      season_code: "SS25",
+      status: "Approved",
+      data: {}
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord,
+      severity,
+    };
+
+    const result = validateSizeRangeSMorLAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.message).toBeUndefined();
+    expect(result.severity).toBe(severity);
+    expect(result.ruleName).toBe(ruleName);
+    expect(result.fieldName).toBe(fieldName);
+    expect(result.newValue).toBe(currentRecord.size_range);
+    expect(result.oldValue).toBe(existingRecord.size_range);
+  });
+
+  it('should pass validation for new entity creation (rule does not apply)', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "SS25-NEW-001",
+      name: "New Item",
+      category: "Apparel",
+      gender: "Unisex",
+      size_range: "XXL", // This value would be invalid for an update, but rule is skipped for creation
+      vertical: "Casual",
+      season_code: "SS25",
+      origin_country: "CN",
+      product_type: "Hoodie"
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord: null, // New creation
+      severity,
+    };
+
+    const result = validateSizeRangeSMorLAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.message).toBeUndefined();
+    expect(result.severity).toBe(severity);
+    expect(result.ruleName).toBe(ruleName);
+    expect(result.fieldName).toBe(fieldName);
+    expect(result.newValue).toBe(currentRecord.size_range);
+    expect(result.oldValue).toBeUndefined();
+    expect(result.context.reason).toContain('Rule applies only to style updates, skipping for new creation.');
+  });
+});

--- a/src/validators/rules/style/index.ts
+++ b/src/validators/rules/style/index.ts
@@ -1,0 +1,1 @@
+export { validateSizeRangeSMorLAllowedValues } from './size-range-s-m-or-l-allowed-values';

--- a/src/validators/rules/style/size-range-s-m-or-l-allowed-values.ts
+++ b/src/validators/rules/style/size-range-s-m-or-l-allowed-values.ts
@@ -1,0 +1,76 @@
+import { ValidationContext, ValidationResult, StyleRequest, MasterStyle } from '../../../types';
+
+/**
+ * Rule: size_range must be one of S, M or L
+ * Entity: Style
+ * Field: size_range
+ * Severity: HARD
+ * When: Update
+ *
+ * Description:
+ * Validates that during a style update, the 'size_range' field is set to one of the
+ * allowed values: 'S', 'M', or 'L'. This ensures consistency for apparel sizing
+ * and prevents invalid size ranges from being saved in the system.
+ */
+export function validateSizeRangeSMorLAllowedValues(
+  context: ValidationContext
+): ValidationResult {
+  const { currentRecord, existingRecord, severity } = context;
+
+  // Cast to StyleRequest since this is a style validation
+  const current = currentRecord as StyleRequest;
+  const existing = existingRecord as MasterStyle | null;
+
+  const allowedSizeRanges = ['S', 'M', 'L'];
+
+  // This rule applies only during an update.
+  // If no existing record, it's a new style creation, and this rule does not apply.
+  if (!existing) {
+    return {
+      valid: true,
+      severity,
+      context: {
+        reason: 'Rule applies only to style updates, skipping for new creation.',
+        style_code: current.style_code,
+        current_size_range: current.size_range,
+      },
+      ruleName: 'SizeRangeSMorLAllowedValues',
+      fieldName: 'size_range',
+      newValue: current.size_range,
+    };
+  }
+
+  // If it's an update, check if the current size_range is one of the allowed values
+  if (!allowedSizeRanges.includes(current.size_range)) {
+    return {
+      valid: false,
+      message: `The 'size_range' value '${current.size_range}' is not allowed during update. It must be one of: ${allowedSizeRanges.join(', ')}.`, 
+      severity,
+      context: {
+        allowed_values: allowedSizeRanges,
+        style_code: current.style_code,
+        current_size_range: current.size_range,
+        previous_size_range: existing.size_range,
+      },
+      ruleName: 'SizeRangeSMorLAllowedValues',
+      fieldName: 'size_range',
+      oldValue: existing.size_range,
+      newValue: current.size_range,
+    };
+  }
+
+  // If the size_range is valid for an update
+  return {
+    valid: true,
+    severity,
+    context: {
+      style_code: current.style_code,
+      current_size_range: current.size_range,
+      previous_size_range: existing.size_range,
+    },
+    ruleName: 'SizeRangeSMorLAllowedValues',
+    fieldName: 'size_range',
+    oldValue: existing.size_range,
+    newValue: current.size_range,
+  };
+}


### PR DESCRIPTION
size_range must be one of S, M or L, it's a hard rule

This PR adds validation for `size_range` on `Style` entity.

Validation Logic:
- During an update, the `size_range` field must be one of the specified allowed values: 'S', 'M', or 'L'.
- This rule applies only during style updates.

Severity: HARD