### PR TITLE
feat: Add validation rule - GenderAllowedValues

### DIFF
--- a/src/validators/rules/style/__tests__/gender-allowed-values.test.ts
+++ b/src/validators/rules/style/__tests__/gender-allowed-values.test.ts
@@ -1,0 +1,161 @@
+import { validateGenderAllowedValues } from '../gender-allowed-values';
+import { ValidationContext, StyleRequest, MasterStyle } from '../../../types';
+
+describe('validateGenderAllowedValues', () => {
+  const baseExistingStyle: MasterStyle = {
+    style_code: 'SS24-TS-001',
+    name: 'Summer Basic T-Shirt',
+    category: 'Apparel',
+    gender: 'M',
+    size_range: 'XS-XL',
+    vertical: 'Casualwear',
+    season_code: 'SS24',
+    status: 'Active',
+    data: {}
+  };
+
+  it('should fail validation when updating with an invalid gender value (U)', () => {
+    const currentRecord: StyleRequest = {
+      style_code: 'SS24-TS-001',
+      name: 'Summer Basic T-Shirt',
+      category: 'Apparel',
+      gender: 'U', // Invalid gender
+      size_range: 'XS-XL',
+      vertical: 'Casualwear',
+      season_code: 'SS24',
+      origin_country: 'China',
+      product_type: 'T-Shirt'
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord: { ...baseExistingStyle, gender: 'M' }, // Existing gender is valid
+      severity: 'HARD',
+    };
+
+    const result = validateGenderAllowedValues(context);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("The 'gender' field value 'U' is not allowed. It must be either 'M' or 'W'.");
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('gender');
+    expect(result.oldValue).toBe('M');
+    expect(result.newValue).toBe('U');
+    expect(result.ruleName).toBe('GenderAllowedValues');
+  });
+
+  it('should pass validation when updating with a valid gender value (M)', () => {
+    const currentRecord: StyleRequest = {
+      style_code: 'SS24-TS-001',
+      name: 'Summer Basic T-Shirt',
+      category: 'Apparel',
+      gender: 'M', // Valid gender
+      size_range: 'XS-XL',
+      vertical: 'Casualwear',
+      season_code: 'SS24',
+      origin_country: 'China',
+      product_type: 'T-Shirt'
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord: { ...baseExistingStyle, gender: 'W' }, // Existing gender is valid
+      severity: 'HARD',
+    };
+
+    const result = validateGenderAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('gender');
+    expect(result.oldValue).toBe('W');
+    expect(result.newValue).toBe('M');
+    expect(result.ruleName).toBe('GenderAllowedValues');
+  });
+
+  it('should pass validation when updating with a valid gender value (W)', () => {
+    const currentRecord: StyleRequest = {
+      style_code: 'SS24-TS-002',
+      name: 'Winter Jacket',
+      category: 'Outerwear',
+      gender: 'W', // Valid gender
+      size_range: 'S-L',
+      vertical: 'Performance',
+      season_code: 'FW24',
+      origin_country: 'Vietnam',
+      product_type: 'Jacket'
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord: { ...baseExistingStyle, style_code: 'SS24-TS-002', gender: 'M' },
+      severity: 'HARD',
+    };
+
+    const result = validateGenderAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('gender');
+    expect(result.oldValue).toBe('M');
+    expect(result.newValue).toBe('W');
+    expect(result.ruleName).toBe('GenderAllowedValues');
+  });
+
+  it('should pass validation for new style creation (existingRecord is null)', () => {
+    const currentRecord: StyleRequest = {
+      style_code: 'NEW-TS-001',
+      name: 'New Style',
+      category: 'Apparel',
+      gender: 'X', // Even an invalid gender passes for new creation as rule applies to updates
+      size_range: 'XS-XL',
+      vertical: 'Casualwear',
+      season_code: 'SS25',
+      origin_country: 'India',
+      product_type: 'T-Shirt'
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord: null, // New entity creation
+      severity: 'HARD',
+    };
+
+    const result = validateGenderAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('gender');
+    expect(result.newValue).toBe('X');
+    expect(result.ruleName).toBe('GenderAllowedValues');
+  });
+
+  it('should pass validation if gender is unchanged and valid', () => {
+    const currentRecord: StyleRequest = {
+      style_code: 'SS24-TS-001',
+      name: 'Summer Basic T-Shirt',
+      category: 'Apparel',
+      gender: 'M', // Gender remains 'M'
+      size_range: 'XS-XL',
+      vertical: 'Casualwear',
+      season_code: 'SS24',
+      origin_country: 'China',
+      product_type: 'T-Shirt'
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord: { ...baseExistingStyle, gender: 'M' }, // Existing gender is 'M'
+      severity: 'HARD',
+    };
+
+    const result = validateGenderAllowedValues(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe('HARD');
+    expect(result.fieldName).toBe('gender');
+    expect(result.oldValue).toBe('M');
+    expect(result.newValue).toBe('M');
+    expect(result.ruleName).toBe('GenderAllowedValues');
+  });
+});

--- a/src/validators/rules/style/gender-allowed-values.ts
+++ b/src/validators/rules/style/gender-allowed-values.ts
@@ -1,0 +1,74 @@
+/**
+ * Rule: Gender should be one of M or W
+ * Entity: Style
+ * Field: gender
+ * Severity: HARD
+ * When: Update
+ * 
+ * Description:
+ * Validates that the 'gender' field for a Style entity is restricted to specific
+ * allowed values: 'M' (Male) or 'W' (Female). This ensures data consistency
+ * and adherence to defined product attributes during updates.
+ */
+import { ValidationContext, ValidationResult, StyleRequest, MasterStyle } from '../../../types';
+
+export function validateGenderAllowedValues(
+  context: ValidationContext
+): ValidationResult {
+  const { currentRecord, existingRecord, severity } = context;
+  
+  // Cast to StyleRequest since this is a style validation
+  const current = currentRecord as StyleRequest;
+  const existing = existingRecord as MasterStyle | null;
+  
+  // This rule applies only to updates. If no existing record, it's a new creation,
+  // and this specific rule does not apply (it will be caught by creation-time rules if needed).
+  if (!existing) {
+    return {
+      valid: true,
+      severity,
+      context: {
+        reason: 'New style creation - rule applies only to updates',
+        style_code: current.style_code
+      },
+      ruleName: 'GenderAllowedValues',
+      fieldName: 'gender',
+      newValue: current.gender,
+    };
+  }
+
+  // Define allowed gender values
+  const allowedGenders = ['M', 'W'];
+
+  // Check if the current gender value is within the allowed list
+  if (!allowedGenders.includes(current.gender)) {
+    return {
+      valid: false,
+      message: `The 'gender' field value '${current.gender}' is not allowed. It must be either 'M' or 'W'.`,
+      severity,
+      context: {
+        style_code: current.style_code,
+        allowed_values: allowedGenders,
+        current_gender: current.gender,
+      },
+      ruleName: 'GenderAllowedValues',
+      fieldName: 'gender',
+      oldValue: existing.gender,
+      newValue: current.gender,
+    };
+  }
+  
+  // If the gender is one of the allowed values, the validation passes
+  return {
+    valid: true,
+    severity,
+    context: {
+      style_code: current.style_code,
+      current_gender: current.gender,
+    },
+    ruleName: 'GenderAllowedValues',
+    fieldName: 'gender',
+    oldValue: existing.gender,
+    newValue: current.gender,
+  };
+}

--- a/src/validators/rules/style/index.ts
+++ b/src/validators/rules/style/index.ts
@@ -1,0 +1,1 @@
+export { validateGenderAllowedValues } from './gender-allowed-values';


### PR DESCRIPTION
Gender should be one of M or W

This PR adds validation for `gender` on `Style` entity.

Validation Logic:
- The `gender` field must be one of 'M' (Male) or 'W' (Female).
- This rule applies only during updates to an existing style.

Severity: HARD