### PR TITLE
feat: Add validation rule - StyleNameImmutableAfterCreation

### DIFF
--- a/src/validators/rules/style/__tests__/style-name-immutable-after-creation.test.ts
+++ b/src/validators/rules/style/__tests__/style-name-immutable-after-creation.test.ts
@@ -1,0 +1,247 @@
+import { validateStyleNameImmutableAfterCreation } from '../style-name-immutable-after-creation';
+import { ValidationContext, StyleRequest, MasterStyle } from '../../../types';
+
+describe('validateStyleNameImmutableAfterCreation', () => {
+  const ruleName = 'StyleNameImmutableAfterCreation';
+  const fieldName = 'name';
+  const severity = 'HARD'; // As per approved rule
+
+  it('should fail validation when style name is changed on an existing record', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "FW24-SH-001",
+      name: "Classic Running Shoe v2.0", // Changed
+      category: "Footwear",
+      gender: "Unisex",
+      size_range: "US 5-12",
+      vertical: "Performance",
+      season_code: "FW24",
+      origin_country: "Vietnam",
+      product_type: "Sneaker"
+    };
+
+    const existingRecord: MasterStyle = {
+      style_code: "FW24-SH-001",
+      name: "Classic Running Shoe", // Original
+      category: "Footwear",
+      gender: "Unisex",
+      size_range: "US 5-12",
+      vertical: "Performance",
+      season_code: "FW24",
+      status: "Approved",
+      data: {}
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord,
+      severity,
+    };
+
+    const result = validateStyleNameImmutableAfterCreation(context);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('Style name cannot be changed after creation.');
+    expect(result.message).toContain(`Previous: "${existingRecord.name}", Current: "${currentRecord.name}".`);
+    expect(result.severity).toBe(severity);
+    expect(result.ruleName).toBe(ruleName);
+    expect(result.fieldName).toBe(fieldName);
+    expect(result.oldValue).toBe(existingRecord.name);
+    expect(result.newValue).toBe(currentRecord.name);
+    expect(result.context).toEqual(expect.objectContaining({
+      style_code: currentRecord.style_code,
+      previous_name: existingRecord.name,
+      current_name: currentRecord.name,
+    }));
+  });
+
+  it('should pass validation when style name remains unchanged on an existing record', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "FW24-TS-005",
+      name: "Organic Cotton Tee", // Unchanged
+      category: "Apparel",
+      gender: "Female",
+      size_range: "XS-XL",
+      vertical: "Lifestyle",
+      season_code: "FW24",
+      origin_country: "Portugal",
+      product_type: "T-Shirt"
+    };
+
+    const existingRecord: MasterStyle = {
+      style_code: "FW24-TS-005",
+      name: "Organic Cotton Tee", // Original
+      category: "Apparel",
+      gender: "Female",
+      size_range: "XS-XL",
+      vertical: "Lifestyle",
+      season_code: "FW24",
+      status: "In Development",
+      data: {}
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord,
+      severity,
+    };
+
+    const result = validateStyleNameImmutableAfterCreation(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe(severity);
+    expect(result.ruleName).toBe(ruleName);
+    expect(result.fieldName).toBe(fieldName);
+    expect(result.oldValue).toBe(existingRecord.name);
+    expect(result.newValue).toBe(currentRecord.name);
+    expect(result.context).toEqual(expect.objectContaining({
+      reason: 'Style name remains unchanged (or only whitespace adjusted).',
+      style_code: currentRecord.style_code,
+    }));
+  });
+
+  it('should pass validation for new style creation (no existing record)', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "SS25-JK-010",
+      name: "Lightweight Summer Jacket",
+      category: "Apparel",
+      gender: "Male",
+      size_range: "S-XXL",
+      vertical: "Outdoor",
+      season_code: "SS25",
+      origin_country: "China",
+      product_type: "Jacket"
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord: null, // New creation
+      severity,
+    };
+
+    const result = validateStyleNameImmutableAfterCreation(context);
+
+    expect(result.valid).toBe(true);
+    expect(result.severity).toBe(severity);
+    expect(result.ruleName).toBe(ruleName);
+    expect(result.fieldName).toBe(fieldName);
+    expect(result.oldValue).toBeNull();
+    expect(result.newValue).toBe(currentRecord.name);
+    expect(result.context).toEqual(expect.objectContaining({
+      reason: 'New style creation - name is being set for the first time.',
+      style_code: currentRecord.style_code,
+    }));
+  });
+
+  it('should pass if only leading/trailing whitespace changes for the name', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "FW24-TS-005",
+      name: "  Organic Cotton Tee  ", // Current with whitespace
+      category: "Apparel",
+      gender: "Female",
+      size_range: "XS-XL",
+      vertical: "Lifestyle",
+      season_code: "FW24",
+      origin_country: "Portugal",
+      product_type: "T-Shirt"
+    };
+
+    const existingRecord: MasterStyle = {
+      style_code: "FW24-TS-005",
+      name: "Organic Cotton Tee", // Original without whitespace
+      category: "Apparel",
+      gender: "Female",
+      size_range: "XS-XL",
+      vertical: "Lifestyle",
+      season_code: "FW24",
+      status: "In Development",
+      data: {}
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord,
+      severity,
+    };
+
+    const result = validateStyleNameImmutableAfterCreation(context);
+    expect(result.valid).toBe(true); // Should pass because trimmed names are equal
+  });
+
+  it('should fail if name changes from null to a value', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "FW24-TS-005",
+      name: "Organic Cotton Tee",
+      category: "Apparel",
+      gender: "Female",
+      size_range: "XS-XL",
+      vertical: "Lifestyle",
+      season_code: "FW24",
+      origin_country: "Portugal",
+      product_type: "T-Shirt"
+    };
+
+    const existingRecord: MasterStyle = {
+      style_code: "FW24-TS-005",
+      name: null, // Original was null
+      category: "Apparel",
+      gender: "Female",
+      size_range: "XS-XL",
+      vertical: "Lifestyle",
+      season_code: "FW24",
+      status: "In Development",
+      data: {}
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord,
+      severity,
+    };
+
+    const result = validateStyleNameImmutableAfterCreation(context);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('Style name cannot be changed after creation.');
+    expect(result.message).toContain(`Previous: "null", Current: "${currentRecord.name}".`);
+    expect(result.oldValue).toBeNull();
+    expect(result.newValue).toBe(currentRecord.name);
+  });
+
+  it('should fail if name changes from a value to null', () => {
+    const currentRecord: StyleRequest = {
+      style_code: "FW24-TS-005",
+      name: null, // Current is null
+      category: "Apparel",
+      gender: "Female",
+      size_range: "XS-XL",
+      vertical: "Lifestyle",
+      season_code: "FW24",
+      origin_country: "Portugal",
+      product_type: "T-Shirt"
+    };
+
+    const existingRecord: MasterStyle = {
+      style_code: "FW24-TS-005",
+      name: "Organic Cotton Tee", // Original was a value
+      category: "Apparel",
+      gender: "Female",
+      size_range: "XS-XL",
+      vertical: "Lifestyle",
+      season_code: "FW24",
+      status: "In Development",
+      data: {}
+    };
+
+    const context: ValidationContext = {
+      currentRecord,
+      existingRecord,
+      severity,
+    };
+
+    const result = validateStyleNameImmutableAfterCreation(context);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('Style name cannot be changed after creation.');
+    expect(result.message).toContain(`Previous: "${existingRecord.name}", Current: "null".`);
+    expect(result.oldValue).toBe(existingRecord.name);
+    expect(result.newValue).toBeNull();
+  });
+});

--- a/src/validators/rules/style/index.ts
+++ b/src/validators/rules/style/index.ts
@@ -1,0 +1,1 @@
+export { validateStyleNameImmutableAfterCreation } from './style-name-immutable-after-creation';

--- a/src/validators/rules/style/style-name-immutable-after-creation.ts
+++ b/src/validators/rules/style/style-name-immutable-after-creation.ts
@@ -1,0 +1,76 @@
+import { ValidationContext, ValidationResult, StyleRequest, MasterStyle } from '../../../types';
+
+/**
+ * Rule: Style name cannot be changed after creation
+ * Entity: Style
+ * Field: name
+ * Severity: HARD
+ * When: Update
+ *
+ * Description:
+ * This rule ensures that the 'name' field of a Style record remains immutable
+ * once the style has been initially created. Any attempt to modify the style name
+ * on an existing record will result in a hard validation error, maintaining data
+ * integrity and consistency across the product catalog.
+ */
+export function validateStyleNameImmutableAfterCreation(
+  context: ValidationContext
+): ValidationResult {
+  const { currentRecord, existingRecord, severity } = context;
+
+  // Cast to StyleRequest since this is a style validation
+  const current = currentRecord as StyleRequest;
+  const existing = existingRecord as MasterStyle | null;
+
+  // If no existing record, this is a new style creation - always valid for this rule.
+  // The 'name' is being set for the first time.
+  if (!existing) {
+    return {
+      valid: true,
+      severity,
+      context: {
+        reason: 'New style creation - name is being set for the first time.',
+        style_code: current.style_code,
+      },
+      ruleName: 'StyleNameImmutableAfterCreation',
+      fieldName: 'name',
+      newValue: current.name,
+    };
+  }
+
+  // Prepare names for comparison, handling null/undefined and trimming whitespace
+  const currentName = current.name ? String(current.name).trim() : '';
+  const existingName = existing.name ? String(existing.name).trim() : '';
+
+  // Rule violation: name has changed on an existing record
+  if (currentName !== existingName) {
+    return {
+      valid: false,
+      message: `Style name cannot be changed after creation. Previous: "${existing.name ?? 'null'}", Current: "${current.name ?? 'null'}".`,
+      severity,
+      context: {
+        style_code: current.style_code,
+        previous_name: existing.name,
+        current_name: current.name,
+      },
+      ruleName: 'StyleNameImmutableAfterCreation',
+      fieldName: 'name',
+      oldValue: existing.name,
+      newValue: current.name,
+    };
+  }
+
+  // Valid: name has not changed (or only whitespace changed, which is ignored)
+  return {
+    valid: true,
+    severity,
+    context: {
+      reason: 'Style name remains unchanged (or only whitespace adjusted).',
+      style_code: current.style_code,
+    },
+    ruleName: 'StyleNameImmutableAfterCreation',
+    fieldName: 'name',
+    oldValue: existing.name,
+    newValue: current.name,
+  };
+}


### PR DESCRIPTION
Style name cannot be changed after creation

This PR adds validation for the `name` field on the `Style` entity.

Validation Logic:
- Prevents modification of the `name` field for an existing style record.

Severity: HARD